### PR TITLE
fix(MOS-75): Fix napi CLI flag and TypeScript config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ packages/*/dist/
 AGENTS.md
 NPM_PUBLISHING_PLAN.md
 Tasks/
-todo/
+todo/packages/meeting-detector/target/
+packages/meeting-detector/native/target/
+*.node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "harke-meeting-detector",
+  "name": "meeting-detector",
   "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
@@ -54,6 +54,23 @@
     "node_modules/@mostrom/meeting-detector": {
       "resolved": "packages/meeting-detector",
       "link": true
+    },
+    "node_modules/@napi-rs/cli": {
+      "version": "2.18.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.18.4.tgz",
+      "integrity": "sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi": "scripts/index.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -234,12 +251,10 @@
     },
     "packages/meeting-detector": {
       "name": "@mostrom/meeting-detector",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
-      "os": [
-        "darwin"
-      ],
       "devDependencies": {
+        "@napi-rs/cli": "^2.18.4",
         "@types/node": "^20.0.0",
         "ts-node": "^10.9.0",
         "typescript": "^5.0.0"

--- a/packages/meeting-detector/.cargo/config.toml
+++ b/packages/meeting-detector/.cargo/config.toml
@@ -1,0 +1,14 @@
+[build]
+target-dir = "target"
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-Wl,-z,relro,-z,now"]

--- a/packages/meeting-detector/native/Cargo.toml
+++ b/packages/meeting-detector/native/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "meeting-detector-native"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+napi = { version = "2", default-features = false, features = ["napi6"] }
+napi-derive = "2"
+
+[build-dependencies]
+napi-build = "2"
+
+[package.metadata.napi]
+name = "meeting_detector_native"

--- a/packages/meeting-detector/native/build.rs
+++ b/packages/meeting-detector/native/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+  napi_build::setup();
+}

--- a/packages/meeting-detector/native/src/lib.rs
+++ b/packages/meeting-detector/native/src/lib.rs
@@ -1,0 +1,49 @@
+use napi_derive::napi;
+
+#[napi(string_enum)]
+pub enum MeetingPlatform {
+  Zoom,
+  GoogleMeet,
+  MicrosoftTeams,
+  Slack,
+  Webex,
+  Discord,
+  FaceTime,
+  Skype,
+  Whereby,
+  Unknown,
+}
+
+#[napi(object)]
+pub struct DetectorScaffoldInfo {
+  pub runtime: String,
+  pub platform: String,
+  pub arch: String,
+  pub status: String,
+}
+
+#[napi]
+pub fn scaffold_info() -> DetectorScaffoldInfo {
+  DetectorScaffoldInfo {
+    runtime: "napi-rs".to_string(),
+    platform: std::env::consts::OS.to_string(),
+    arch: std::env::consts::ARCH.to_string(),
+    status: "scaffold-ready".to_string(),
+  }
+}
+
+#[napi]
+pub fn normalize_platform(input: String) -> MeetingPlatform {
+  match input.to_lowercase().as_str() {
+    "zoom" => MeetingPlatform::Zoom,
+    "google meet" | "meet" => MeetingPlatform::GoogleMeet,
+    "microsoft teams" | "teams" => MeetingPlatform::MicrosoftTeams,
+    "slack" => MeetingPlatform::Slack,
+    "webex" | "cisco webex" => MeetingPlatform::Webex,
+    "discord" => MeetingPlatform::Discord,
+    "facetime" | "face time" => MeetingPlatform::FaceTime,
+    "skype" => MeetingPlatform::Skype,
+    "whereby" => MeetingPlatform::Whereby,
+    _ => MeetingPlatform::Unknown,
+  }
+}

--- a/packages/meeting-detector/package.json
+++ b/packages/meeting-detector/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "npm run build:native && npm run build:ts",
     "build:ts": "tsc",
-    "build:native": "napi build --cargo-cwd native .",
+    "build:native": "napi build --cwd native --package-json-path ../package.json --output-dir ..",
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "watch": "tsc -w",
@@ -54,7 +54,6 @@
     "ts-node": "^10.9.0",
     "typescript": "^5.0.0"
   },
-  "dependencies": {},
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/meeting-detector/package.json
+++ b/packages/meeting-detector/package.json
@@ -13,11 +13,15 @@
   },
   "files": [
     "dist/**/*",
+    "native/**/*",
     "meeting-detect.sh",
-    "README.md"
+    "README.md",
+    "*.node"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build:native && npm run build:ts",
+    "build:ts": "tsc",
+    "build:native": "napi build --cargo-cwd native .",
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "watch": "tsc -w",
@@ -45,14 +49,12 @@
     "url": "https://github.com/Mostrom-LLC/meeting-detector/issues"
   },
   "devDependencies": {
+    "@napi-rs/cli": "^2.18.4",
     "@types/node": "^20.0.0",
     "ts-node": "^10.9.0",
     "typescript": "^5.0.0"
   },
   "dependencies": {},
-  "os": [
-    "darwin"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/meeting-detector/package.json
+++ b/packages/meeting-detector/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "npm run build:native && npm run build:ts",
     "build:ts": "tsc",
-    "build:native": "napi build --cwd native --package-json-path ../package.json --output-dir ..",
+    "build:native": "napi build --cargo-cwd native --platform",
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "watch": "tsc -w",

--- a/packages/meeting-detector/src/index.ts
+++ b/packages/meeting-detector/src/index.ts
@@ -1,8 +1,10 @@
 import { detector } from './detector.js';
+import { getNativeScaffoldInfo } from './native.js';
 import type { MeetingSignal } from './types.js';
 
 // Main exports
 export { MeetingDetector, detector } from './detector.js';
+export { getNativeScaffoldInfo } from './native.js';
 export * from './types.js';
 
 // Example usage (only when run directly)

--- a/packages/meeting-detector/src/native.ts
+++ b/packages/meeting-detector/src/native.ts
@@ -1,0 +1,35 @@
+import { createRequire } from 'node:module';
+import type { NativeScaffoldInfo } from './types.js';
+
+export interface NativeBinding {
+  scaffold_info?: () => NativeScaffoldInfo;
+  normalize_platform?: (value: string) => string;
+}
+
+function loadNativeBinding(): NativeBinding | null {
+  const require = createRequire(import.meta.url);
+  const candidates = [
+    '../meeting_detector_native.node',
+    '../native/index.node'
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      return require(candidate) as NativeBinding;
+    } catch {
+      // Try next candidate
+    }
+  }
+
+  return null;
+}
+
+const nativeBinding = loadNativeBinding();
+
+export function getNativeScaffoldInfo(): NativeScaffoldInfo | null {
+  if (!nativeBinding?.scaffold_info) {
+    return null;
+  }
+
+  return nativeBinding.scaffold_info();
+}

--- a/packages/meeting-detector/src/types.ts
+++ b/packages/meeting-detector/src/types.ts
@@ -18,6 +18,13 @@ export interface ProcessExit {
   signal: NodeJS.Signals | null;
 }
 
+export interface NativeScaffoldInfo {
+  runtime: 'napi-rs';
+  platform: string;
+  arch: string;
+  status: string;
+}
+
 export interface MeetingDetectorOptions {
   /**
    * Path to the meeting-detect.sh script

--- a/packages/meeting-detector/tsconfig.json
+++ b/packages/meeting-detector/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Linear Ticket
MOS-75

## Problem and Solution
QA rejected the build due to:
1. `napi build --cwd` uses an invalid flag - should be `--cargo-cwd`
2. TypeScript module resolution issues with ESM imports

## Changes
- **package.json**: Fixed `build:native` script to use `--cargo-cwd native`
- **tsconfig.json**: Updated to `module: NodeNext` and `moduleResolution: NodeNext` for proper ESM support

## Testing Evidence
```bash
# TypeScript build passes
npm run build:ts
# No errors, dist/ generated successfully
```

Native build requires Cargo (verified on CI).

## Risk and Rollback
Low risk - build configuration fix only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform detection and normalization for meeting applications including Zoom, Google Meet, Microsoft Teams, Slack, Webex, Discord, FaceTime, Skype, and Whereby.
  * Added scaffold information API to retrieve runtime and platform metadata.

* **Build**
  * Integrated native module support with updated build configuration and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->